### PR TITLE
Rename CSS class name "hidden" to "wp-rag-hidden" to avoid conflicts

### DIFF
--- a/core/includes/assets/css/frontend-styles.css
+++ b/core/includes/assets/css/frontend-styles.css
@@ -188,6 +188,6 @@ Frontend related CSS
 	visibility: visible;
 }
 
-.hidden {
+.wp-rag-hidden {
 	display: none !important;
 }

--- a/core/includes/assets/js/frontend-scripts.js
+++ b/core/includes/assets/js/frontend-scripts.js
@@ -56,22 +56,22 @@ Frontend related javascript
 
 			const isMinimized = localStorage.getItem( 'wp-rag-chat-minimized' ) === 'true';
 			if (isMinimized) {
-				chatWindow.addClass( 'hidden' );
-				chatIcon.removeClass( 'hidden' );
+				chatWindow.addClass( 'wp-rag-hidden' );
+				chatIcon.removeClass( 'wp-rag-hidden' );
 			}
 			minimizeButton.on(
 				'click',
 				function () {
-					chatWindow.addClass( 'hidden' );
-					chatIcon.removeClass( 'hidden' );
+					chatWindow.addClass( 'wp-rag-hidden' );
+					chatIcon.removeClass( 'wp-rag-hidden' );
 					localStorage.setItem( 'wp-rag-chat-minimized', 'true' );
 				}
 			);
 			chatIcon.on(
 				'click',
 				function () {
-					chatWindow.removeClass( 'hidden' );
-					chatIcon.addClass( 'hidden' );
+					chatWindow.removeClass( 'wp-rag-hidden' );
+					chatIcon.addClass( 'wp-rag-hidden' );
 					localStorage.setItem( 'wp-rag-chat-minimized', 'false' );
 					input.focus();
 				}

--- a/core/includes/classes/class-wp-rag-frontend.php
+++ b/core/includes/classes/class-wp-rag-frontend.php
@@ -76,7 +76,7 @@ class Wp_Rag_Frontend {
 				</form>
 			</div>
 		</div>
-		<div id="wp-rag-chat-icon" class="wp-rag-chat-icon hidden">
+		<div id="wp-rag-chat-icon" class="wp-rag-chat-icon wp-rag-hidden">
 			<span class="dashicons dashicons-admin-comments"></span>
 			<span class="wp-rag-chat-icon-tooltip">Open <?php echo esc_html( $title ); ?></span>
 		</div>


### PR DESCRIPTION
Rename CSS class name "hidden" to "wp-rag-hidden" to avoid conflicts. (The theme of our company's blog site uses `hidden` class for an element that should be visible.)