### PR TITLE
Show site id and free api key

### DIFF
--- a/core/includes/assets/css/admin-clipboard.css
+++ b/core/includes/assets/css/admin-clipboard.css
@@ -1,0 +1,23 @@
+.wp-rag-copy-btn {
+	background: #007bff;
+	color: white;
+	border: none;
+	margin: 0 5px;
+	padding: 2px 5px;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: 12px;
+	transition: all 0.2s;
+	display: flex;
+	align-items: center;
+	gap: 5px;
+}
+
+.wp-rag-copy-btn:hover {
+	background: #0056b3;
+	transform: translateY(-1px);
+}
+
+.wp-rag-copy-btn.copied {
+	background: #28a745;
+}

--- a/core/includes/assets/css/admin-clipboard.css
+++ b/core/includes/assets/css/admin-clipboard.css
@@ -1,5 +1,5 @@
 .wp-rag-copy-btn {
-	background: #007bff;
+	background: #2271b1;
 	color: white;
 	border: none;
 	margin: 0 5px;

--- a/core/includes/assets/js/admin-clipboard.js
+++ b/core/includes/assets/js/admin-clipboard.js
@@ -1,0 +1,32 @@
+/**
+ * Copies the text of the given element.
+ *
+ * @param {string} elementId
+ * @param {*} button
+ */
+async function copyToClipboard(elementId, button) {
+	try {
+		const element = document.getElementById( elementId );
+		const text    = element.textContent;
+
+		await navigator.clipboard.writeText( text );
+
+		// Change the button to the "copied" status.
+		const originalText = button.innerHTML;
+		button.innerHTML   = '📋 Copied';
+		button.classList.add( 'copied' );
+
+		// Put it back to the original after 2 seconds.
+		setTimeout(
+			() => {
+				button.innerHTML = originalText;
+				button.classList.remove( 'copied' );
+			},
+			2000
+		);
+
+	} catch (err) {
+		console.error( 'Failed to copy the value to the clipboard:', err );
+		alert( 'Failed to copy the value to the clipboard. Please copy it manually.' );
+	}
+}

--- a/core/includes/classes/class-wp-rag-page-general-settings.php
+++ b/core/includes/classes/class-wp-rag-page-general-settings.php
@@ -74,11 +74,11 @@ class Wp_Rag_Page_GeneralSettings {
 		<?php
 	}
 
-	public function add_auth_section_and_fields() {
+	public function add_registration_section_and_fields() {
 		add_settings_section(
-			'wp_rag_auth_section', // Section ID
+			'wp_rag_registration_section', // Section ID
 			'WP RAG Registration', // Title
-			array( $this, 'auth_section_callback' ), // Callback
+			array( $this, 'registration_section_callback' ), // Callback
 			'wp-rag-general-settings', // Page slug
 		);
 
@@ -87,7 +87,7 @@ class Wp_Rag_Page_GeneralSettings {
 			'API key',
 			array( $this, 'paid_api_key_field_render' ), // callback
 			'wp-rag-general-settings', // Page slug
-			'wp_rag_auth_section'
+			'wp_rag_registration_section'
 		);
 	}
 
@@ -117,7 +117,7 @@ class Wp_Rag_Page_GeneralSettings {
 		);
 	}
 
-	function auth_section_callback() {
+	function registration_section_callback() {
 		echo 'If you have an API key, fill in the API key field. If not, leave it blank.' . '<br />';
 		if ( ! WPRAG()->helpers->is_verified() ) {
 			if ( WPRAG()->helpers->get_auth_data( 'site_id' ) ) {

--- a/core/includes/classes/class-wp-rag-page-main.php
+++ b/core/includes/classes/class-wp-rag-page-main.php
@@ -91,7 +91,7 @@ class Wp_Rag_Page_Main {
 				<input type="submit" name="wp_rag_query_submit" class="button button-primary" value="Query">
 			</form>
 			<?php if ( ! empty( $this->response ) ) : ?>
-				<p>Qustion: <?php echo esc_html( wp_unslash( $_POST['wp_rag_question'] ) ); ?></p>
+				<p>Question: <?php echo esc_html( wp_unslash( $_POST['wp_rag_question'] ) ); ?></p>
 				<p>Answer: <?php echo esc_html( $this->response['response']['answer'] ); ?></p>
 				Context posts:
 				<ul>

--- a/core/includes/classes/class-wp-rag-page-main.php
+++ b/core/includes/classes/class-wp-rag-page-main.php
@@ -19,6 +19,23 @@ class Wp_Rag_Page_Main {
 
 	private $response = array();
 
+	public function enqueue_scripts_and_styles() {
+		wp_enqueue_script(
+			'wp-rag-admin-clipboard',
+			plugins_url( 'core/includes/assets/js/admin-clipboard.js', WPRAG_PLUGIN_FILE ),
+			array( 'jquery' ),
+			WPRAG_VERSION,
+			true
+		);
+
+		wp_enqueue_style(
+			'wp-rag-admin-notices',
+			plugins_url( 'core/includes/assets/css/admin-clipboard.css', WPRAG_PLUGIN_FILE ),
+			array(),
+			WPRAG_VERSION
+		);
+	}
+
 	/**
 	 * Renders the main page
 	 *
@@ -39,6 +56,21 @@ class Wp_Rag_Page_Main {
 		?>
 		<div class="wrap">
 			<h2>WP RAG</h2>
+			<h3>Site Info</h3>
+			<ul>
+				<li style="display: flex;">
+					Site ID: <div id="wp-rag-main-site-id"><?php echo esc_html( WPRAG()->helpers->get_auth_data( 'site_id' ) ); ?></div>
+					<button class="wp-rag-copy-btn" onclick="copyToClipboard('wp-rag-main-site-id', this)">
+						📋 Copy
+					</button>
+				</li>
+				<li style="display: flex;">
+					API key: <div id="wp-rag-main-api-key"><?php echo esc_html( WPRAG()->helpers->get_auth_data( 'free_api_key' ) ); ?></div>
+					<button class="wp-rag-copy-btn" onclick="copyToClipboard('wp-rag-main-api-key', this)">
+						📋 Copy
+					</button>
+				</li>
+			</ul>
 			<h3>System Status</h3>
 			<ul>
 				<li>✅: This WordPress site is verified.</li>

--- a/core/includes/classes/class-wp-rag-page-main.php
+++ b/core/includes/classes/class-wp-rag-page-main.php
@@ -42,7 +42,7 @@ class Wp_Rag_Page_Main {
 			<h3>System Status</h3>
 			<ul>
 				<li>✅: This WordPress site is verified.</li>
-				<li><?php echo isset( $ai_options['openai_api_key'] ) ? '✅' : '❌'; ?>: OpenAI API Key is set.</li>
+				<li><?php echo isset( $ai_options['openai_api_key'] ) ? '✅: OpenAI API Key is set.' : '❌: OpenAI API Key is not set.'; ?></li>
 				<li><?php echo $status['post_count'] > 0 ? '✅' : '❌'; ?>: Number of the posts imported to the WP RAG API is <?php echo esc_html( $status['post_count'] ); ?>.</li>
 				<li><?php echo $status['embedding_count'] > 0 ? '✅' : '❌'; ?>: Number of the created embeddings is <?php echo esc_html( $status['embedding_count'] ); ?>.</li>
 			</ul>

--- a/core/includes/classes/class-wp-rag-run.php
+++ b/core/includes/classes/class-wp-rag-run.php
@@ -293,7 +293,7 @@ class Wp_Rag_Run {
 				),
 			);
 
-			$cls->add_auth_section_and_fields();
+			$cls->add_registration_section_and_fields();
 			$cls->add_config_section_and_fields();
 		} elseif ( 'wp-rag-ai-configuration' === $current_page || 'wp-rag-ai-configuration' === $referer_page ) {
 			Wp_Rag_AdminMessages::get_instance(); // To load the JS, CSS and template.

--- a/core/includes/classes/class-wp-rag-run.php
+++ b/core/includes/classes/class-wp-rag-run.php
@@ -272,6 +272,8 @@ class Wp_Rag_Run {
 			// TODO Check nonce.
 			$cls = WPRAG()->pages['main'];
 
+			$cls->enqueue_scripts_and_styles();
+
 			if ( isset( $_POST['wp_rag_import_submit'] ) ) {
 				$cls->handle_import_form_submission();
 			}


### PR DESCRIPTION
## What

* Show the site ID and free API key on the main page
* Other small fixes:
  * [Rename auth_section to registration_section](https://github.com/mobalab/wp-rag/pull/43/commits/0460dca4d2f24ed3ba1cbb4df7c86d8bf0acc479)
  * [Fix message on main page](https://github.com/mobalab/wp-rag/pull/43/commits/45b4283fed6875c05794a2311f8cfc33be5af16c)
  * [Fix typo](https://github.com/mobalab/wp-rag/pull/43/commits/886ab73a5a18bfa1816f533d88742aa7bd689c79)

## How to test
### Main feature

Go to the plugin's main page.

Confirm the following:
* The site ID and free API key are displayed.
* The copy buttons work.

### Small fixes

* Go to the main page, and confirm there are no errors.
* Go to the "General Settings" page, and confirm there are no errors.