### PR TITLE
Extending timeout

### DIFF
--- a/core/includes/classes/class-wp-rag-helpers.php
+++ b/core/includes/classes/class-wp-rag-helpers.php
@@ -135,7 +135,7 @@ class Wp_Rag_Helpers {
 				),
 				$headers
 			),
-			'timeout' => 15,
+			'timeout' => 30,
 		);
 
 		if ( null !== $data ) {


### PR DESCRIPTION
`POST /api/sites/:id/query` can sometimes take more than 15 seconds, especially when using `openai-o1-preview` for generation. So I want to extend the API call timeout.