### PR TITLE
Add premium key feature

### DIFF
--- a/core/includes/classes/class-wp-rag-helpers.php
+++ b/core/includes/classes/class-wp-rag-helpers.php
@@ -94,8 +94,10 @@ class Wp_Rag_Helpers {
 	}
 
 	public function call_api_for_site( $api_sub_path, $method = 'GET', $data = null, $headers = array() ) {
-		$site_id      = WPRAG()->helpers->get_auth_data( 'site_id' );
-		$free_api_key = WPRAG()->helpers->get_auth_data( 'free_api_key' );
+		$site_id         = WPRAG()->helpers->get_auth_data( 'site_id' );
+		$premium_api_key = WPRAG()->helpers->get_auth_data( 'premium_api_key' );
+		$free_api_key    = WPRAG()->helpers->get_auth_data( 'free_api_key' );
+
 		if ( empty( $site_id ) ) {
 			wp_die( 'site_id is not set' );
 		}
@@ -104,7 +106,10 @@ class Wp_Rag_Helpers {
 		$api_path = "/api/sites/{$site_id}/{$api_sub_path}";
 		$api_path = rtrim( $api_path, '/' );
 
-		if ( ! empty( $free_api_key ) ) {
+		// Use premium API key if available, otherwise use free API key
+		if ( ! empty( $premium_api_key ) ) {
+			$headers['X-Api-Key'] = $premium_api_key;
+		} elseif ( ! empty( $free_api_key ) ) {
 			$headers['X-Api-Key'] = $free_api_key;
 		}
 
@@ -165,24 +170,36 @@ class Wp_Rag_Helpers {
 	 * @return bool True if verified, otherwise false
 	 */
 	public function is_verified() {
-		return ! empty( $this->get_auth_data( 'verified_at' ) );
+		return ! empty( $this->get_auth_data( 'verified_at' ) ) || ! empty( $this->get_auth_data( 'premium_api_key' ) );
 	}
 
 	/**
 	 * Registers the site on the API.
 	 *
+	 * @param string $premium_api_key Optional premium API key
 	 * @return bool
 	 */
-	public function register_site(): bool {
+	public function register_site( $premium_api_key = '' ): bool {
 		$api_path = '/api/sites';
 		$data     = array( 'url' => get_site_url() );
+
+		// Add premium API key if provided
+		if ( ! empty( $premium_api_key ) ) {
+			$data['premium_api_key'] = $premium_api_key;
+		}
+
 		$response = WPRAG()->helpers->call_api( $api_path, 'POST', $data );
 
 		if ( 201 !== $response['httpCode'] ) {
+			$error_message = 'API error: status=' . $response['httpCode'];
+			if ( isset( $response['response']['message'] ) ) {
+				$error_message = $response['response']['message'];
+			}
+
 			add_settings_error(
 				'wp_rag_messages',
 				'wp_rag_message',
-				'API error: status=' . $response['httpCode'] . ', response=' . wp_json_encode( $response['response'] ),
+				$error_message,
 				'error'
 			);
 			return false;
@@ -190,10 +207,27 @@ class Wp_Rag_Helpers {
 			$auth_data                      = WPRAG()->helpers->get_auth_data();
 			$auth_data['site_id']           = $response['response']['id'];
 			$auth_data['free_api_key']      = $response['response']['free_api_key'];
-			$auth_data['verification_code'] = $response['response']['verification_code'];
+
+			// Only set verification_code if it exists (not set for premium sites)
+			if ( isset( $response['response']['verification_code'] ) ) {
+				$auth_data['verification_code'] = $response['response']['verification_code'];
+			}
+
+			// Save premium API key if registration was successful
+			if ( ! empty( $premium_api_key ) ) {
+				$auth_data['premium_api_key'] = $premium_api_key;
+				// Premium sites are auto-verified
+				$auth_data['verified_at'] = current_time( 'mysql' );
+				
+				// Save premium API key expiration date if provided
+				if ( isset( $response['response']['premium_api_key_expires_at'] ) ) {
+					$auth_data['premium_api_key_expires_at'] = $response['response']['premium_api_key_expires_at'];
+				}
+			}
+
 			WPRAG()->helpers->save_auth_data( $auth_data );
 
-			// At this point, the site is registered, but not verified yet.
+			// At this point, the site is registered. Premium sites are already verified.
 			return true;
 		}
 	}
@@ -329,5 +363,54 @@ class Wp_Rag_Helpers {
 			'agreed_at' => current_time( 'mysql' ),
 		);
 		update_option( Wp_Rag::OPTION_NAME_FOR_TERMS_PP, $options );
+	}
+
+	/**
+	 * Updates the site with a premium API key.
+	 *
+	 * @param int $site_id The site ID
+	 * @param string $premium_api_key The premium API key to add
+	 * @return bool
+	 */
+	public function update_site_premium_key( $site_id, $premium_api_key ): bool {
+		$api_path = "/api/sites/$site_id";
+		$data     = array(
+			'url' => get_site_url(),
+			'premium_api_key' => $premium_api_key
+		);
+
+		$response = $this->call_api( $api_path, 'PUT', $data, array( 'X-Api-Key' => $this->get_auth_data( 'free_api_key' ) ) );
+
+		if ( 200 !== $response['httpCode'] ) {
+			$error_message = 'Premium API key update failed: status=' . $response['httpCode'];
+			if ( isset( $response['response']['message'] ) ) {
+				$error_message = $response['response']['message'];
+			}
+
+			add_settings_error(
+				'wp_rag_messages',
+				'wp_rag_message',
+				$error_message,
+				'error'
+			);
+			return false;
+		} else {
+			// Update auth data with premium key
+			$this->update_auth_data( 'premium_api_key', $premium_api_key );
+			
+			// Save premium API key expiration date if provided
+			if ( isset( $response['response']['premium_api_key_expires_at'] ) ) {
+				$this->update_auth_data( 'premium_api_key_expires_at', $response['response']['premium_api_key_expires_at'] );
+			}
+
+			add_settings_error(
+				'wp_rag_messages',
+				'wp_rag_message',
+				'Premium API key successfully activated.',
+				'success'
+			);
+
+			return true;
+		}
 	}
 }

--- a/core/includes/classes/class-wp-rag-helpers.php
+++ b/core/includes/classes/class-wp-rag-helpers.php
@@ -106,7 +106,7 @@ class Wp_Rag_Helpers {
 		$api_path = "/api/sites/{$site_id}/{$api_sub_path}";
 		$api_path = rtrim( $api_path, '/' );
 
-		// Use premium API key if available, otherwise use free API key
+		// Use premium API key if available, otherwise use free API key.
 		if ( ! empty( $premium_api_key ) ) {
 			$headers['X-Api-Key'] = $premium_api_key;
 		} elseif ( ! empty( $free_api_key ) ) {
@@ -183,7 +183,7 @@ class Wp_Rag_Helpers {
 		$api_path = '/api/sites';
 		$data     = array( 'url' => get_site_url() );
 
-		// Add premium API key if provided
+		// Add premium API key if provided.
 		if ( ! empty( $premium_api_key ) ) {
 			$data['premium_api_key'] = $premium_api_key;
 		}
@@ -208,18 +208,18 @@ class Wp_Rag_Helpers {
 			$auth_data['site_id']           = $response['response']['id'];
 			$auth_data['free_api_key']      = $response['response']['free_api_key'];
 
-			// Only set verification_code if it exists (not set for premium sites)
+			// Only set verification_code if it exists (not set for premium sites).
 			if ( isset( $response['response']['verification_code'] ) ) {
 				$auth_data['verification_code'] = $response['response']['verification_code'];
 			}
 
-			// Save premium API key if registration was successful
+			// Save premium API key if registration was successful.
 			if ( ! empty( $premium_api_key ) ) {
 				$auth_data['premium_api_key'] = $premium_api_key;
-				// Premium sites are auto-verified
+				// Premium sites are auto-verified.
 				$auth_data['verified_at'] = current_time( 'mysql' );
-				
-				// Save premium API key expiration date if provided
+
+				// Save premium API key expiration date if provided.
 				if ( isset( $response['response']['premium_api_key_expires_at'] ) ) {
 					$auth_data['premium_api_key_expires_at'] = $response['response']['premium_api_key_expires_at'];
 				}
@@ -395,10 +395,10 @@ class Wp_Rag_Helpers {
 			);
 			return false;
 		} else {
-			// Update auth data with premium key
+			// Update auth data with premium key.
 			$this->update_auth_data( 'premium_api_key', $premium_api_key );
-			
-			// Save premium API key expiration date if provided
+
+			// Save premium API key expiration date if provided.
 			if ( isset( $response['response']['premium_api_key_expires_at'] ) ) {
 				$this->update_auth_data( 'premium_api_key_expires_at', $response['response']['premium_api_key_expires_at'] );
 			}

--- a/core/includes/classes/class-wp-rag-helpers.php
+++ b/core/includes/classes/class-wp-rag-helpers.php
@@ -227,7 +227,7 @@ class Wp_Rag_Helpers {
 
 			WPRAG()->helpers->save_auth_data( $auth_data );
 
-			// At this point, the site is registered. Premium sites are already verified.
+			// At this point, the site is registered. If a premium key was provided, the site is also verified; otherwise, it remains unverified.
 			return true;
 		}
 	}

--- a/core/includes/classes/class-wp-rag-page-general-settings.php
+++ b/core/includes/classes/class-wp-rag-page-general-settings.php
@@ -28,7 +28,7 @@ class Wp_Rag_Page_GeneralSettings {
 	function save_config_api( $input ) {
 		$sanitized_input = sanitize_post( $input, 'db' );
 
-		// Check if premium API key was submitted
+		// Check if premium API key was submitted.
 		$premium_api_key = '';
 		if ( isset( $_POST['wp_rag_auth_data']['premium_api_key'] ) ) {
 			$premium_api_key = sanitize_text_field( $_POST['wp_rag_auth_data']['premium_api_key'] );
@@ -36,16 +36,16 @@ class Wp_Rag_Page_GeneralSettings {
 
 		$auth_data = WPRAG()->helpers->get_auth_data();
 		if ( empty( $auth_data['site_id'] ) ) {
-			// New site registration
+			// New site registration.
 			if ( ! empty( $premium_api_key ) ) {
-				// Register with premium API key
+				// Register with premium API key.
 				$result = WPRAG()->helpers->register_site( $premium_api_key );
 				if ( ! $result ) {
-					// Registration failed, don't proceed
+					// Registration failed, don't proceed.
 					return get_option( self::OPTION_NAME );
 				}
 			} else {
-				// Register without premium API key (free)
+				// Register without premium API key (free).
 				WPRAG()->helpers->register_site();
 			}
 			WPRAG()->helpers->accept_terms_pp();
@@ -57,7 +57,7 @@ class Wp_Rag_Page_GeneralSettings {
 
 			return get_option( self::OPTION_NAME );
 		} else {
-			// Site is already registered and verified
+			// Site is already registered and verified.
 			$api_path = '/config';
 
 			$response = WPRAG()->helpers->call_api_for_site( $api_path, 'PUT', $sanitized_input );
@@ -72,11 +72,11 @@ class Wp_Rag_Page_GeneralSettings {
 				return get_option( self::OPTION_NAME );
 			}
 
-			// Handle premium API key update for existing sites
+			// Handle premium API key update for existing sites.
 			if ( ! empty( $premium_api_key ) ) {
 				$update_result = WPRAG()->helpers->update_site_premium_key( $auth_data['site_id'], $premium_api_key );
 				if ( ! $update_result ) {
-					// Premium key update failed, but config was saved
+					// Premium key update failed, but config was saved.
 					return get_option( self::OPTION_NAME );
 				}
 			}

--- a/core/includes/classes/class-wp-rag-page-general-settings.php
+++ b/core/includes/classes/class-wp-rag-page-general-settings.php
@@ -28,9 +28,26 @@ class Wp_Rag_Page_GeneralSettings {
 	function save_config_api( $input ) {
 		$sanitized_input = sanitize_post( $input, 'db' );
 
+		// Check if premium API key was submitted
+		$premium_api_key = '';
+		if ( isset( $_POST['wp_rag_auth_data']['premium_api_key'] ) ) {
+			$premium_api_key = sanitize_text_field( $_POST['wp_rag_auth_data']['premium_api_key'] );
+		}
+
 		$auth_data = WPRAG()->helpers->get_auth_data();
 		if ( empty( $auth_data['site_id'] ) ) {
-			WPRAG()->helpers->register_site();
+			// New site registration
+			if ( ! empty( $premium_api_key ) ) {
+				// Register with premium API key
+				$result = WPRAG()->helpers->register_site( $premium_api_key );
+				if ( ! $result ) {
+					// Registration failed, don't proceed
+					return get_option( self::OPTION_NAME );
+				}
+			} else {
+				// Register without premium API key (free)
+				WPRAG()->helpers->register_site();
+			}
 			WPRAG()->helpers->accept_terms_pp();
 
 			return get_option( self::OPTION_NAME );
@@ -40,6 +57,7 @@ class Wp_Rag_Page_GeneralSettings {
 
 			return get_option( self::OPTION_NAME );
 		} else {
+			// Site is already registered and verified
 			$api_path = '/config';
 
 			$response = WPRAG()->helpers->call_api_for_site( $api_path, 'PUT', $sanitized_input );
@@ -52,10 +70,19 @@ class Wp_Rag_Page_GeneralSettings {
 					'error'
 				);
 				return get_option( self::OPTION_NAME );
-			} else {
-				// Pass to the default action.
-				return $sanitized_input;
 			}
+
+			// Handle premium API key update for existing sites
+			if ( ! empty( $premium_api_key ) ) {
+				$update_result = WPRAG()->helpers->update_site_premium_key( $auth_data['site_id'], $premium_api_key );
+				if ( ! $update_result ) {
+					// Premium key update failed, but config was saved
+					return get_option( self::OPTION_NAME );
+				}
+			}
+
+			// Pass to the default action.
+			return $sanitized_input;
 		}
 	}
 
@@ -93,9 +120,9 @@ class Wp_Rag_Page_GeneralSettings {
 		);
 
 		add_settings_field(
-			'wp_rag_paid_api_key',
+			'wp_rag_premium_api_key',
 			'API key',
-			array( $this, 'paid_api_key_field_render' ), // callback
+			array( $this, 'premium_api_key_field_render' ), // callback
 			'wp-rag-general-settings', // Page slug
 			'wp_rag_registration_section'
 		);
@@ -145,7 +172,6 @@ class Wp_Rag_Page_GeneralSettings {
 	}
 
 	function registration_section_callback() {
-		echo 'If you have an API key, fill in the API key field. If not, leave it blank.' . '<br />';
 		if ( ! WPRAG()->helpers->is_verified() ) {
 			if ( WPRAG()->helpers->get_auth_data( 'site_id' ) ) {
 				echo 'Now, waiting for site verification to be completed. Usually, it takes less than a minute.';
@@ -156,9 +182,14 @@ class Wp_Rag_Page_GeneralSettings {
 				if ( isset( $parsed_url['host'] ) && strstr( $parsed_url['host'], '.' ) === false ) {
 					echo "❌ The free version doesn't support WordPress installations on private networks.";
 				} else {
-					echo 'Please "Register" first to use the plugin.';
+					echo 'If you have a premium API key, enter it in the API key field to skip verification. Leave it blank for free registration.';
 				}
 			}
+		} else if ( WPRAG()->helpers->get_auth_data( 'premium_api_key' ) ) {
+			echo '✅ Premium API key is active.';
+			$expires_at = WPRAG()->helpers->get_auth_data( 'premium_api_key_expires_at' );
+			$expires_date = date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $expires_at ) );
+			echo ' Expires on: ' . esc_html( $expires_date );
 		}
 	}
 
@@ -166,11 +197,14 @@ class Wp_Rag_Page_GeneralSettings {
 		echo 'Configure your plugin settings here.';
 	}
 
-	function paid_api_key_field_render() {
+	function premium_api_key_field_render() {
 		$options = get_option( 'wp_rag_auth_data' );
 		?>
-		<input type="text" name="wp_rag_auth_data[paid_api_key]" value="<?php echo esc_attr( $options['paid_api_key'] ?? '' ); ?>">
+		<input type="text" name="wp_rag_auth_data[premium_api_key]" value="<?php echo esc_attr( $options['premium_api_key'] ?? '' ); ?>">
 		<?php
+			if ( WPRAG()->helpers->get_auth_data( 'premium_api_key' ) ) {
+				echo 'Enter a new premium API key to update it.';
+			}
 	}
 
 	function wordpress_user_field_render() {

--- a/core/includes/classes/class-wp-rag-page-main.php
+++ b/core/includes/classes/class-wp-rag-page-main.php
@@ -53,6 +53,8 @@ class Wp_Rag_Page_Main {
 				'post_count'      => 0,
 				'embedding_count' => 0,
 			);
+		$api_key = WPRAG()->helpers->get_auth_data( 'premium_api_key' );
+		$api_key = $api_key ? $api_key : WPRAG()->helpers->get_auth_data( 'free_api_key' );
 		?>
 		<div class="wrap">
 			<h2>WP RAG</h2>
@@ -65,7 +67,7 @@ class Wp_Rag_Page_Main {
 					</button>
 				</li>
 				<li style="display: flex;">
-					API key: <div id="wp-rag-main-api-key"><?php echo esc_html( WPRAG()->helpers->get_auth_data( 'free_api_key' ) ); ?></div>
+					API key: <div id="wp-rag-main-api-key"><?php echo esc_html( $api_key ); ?></div>
 					<button class="wp-rag-copy-btn" onclick="copyToClipboard('wp-rag-main-api-key', this)">
 						📋 Copy
 					</button>


### PR DESCRIPTION
## What

Added Premium API key.

Currently, once a premium API key is registered, it cannot be rotated. We'll implement this when needed.
Also, paid features (like updating AI models) don't yet check whether the API key is a premium one. We'll add that validation later.
