### PR TITLE
Fix bug that "Register" button is always disabled

### DIFF
--- a/core/includes/classes/class-wp-rag-helpers.php
+++ b/core/includes/classes/class-wp-rag-helpers.php
@@ -307,6 +307,17 @@ class Wp_Rag_Helpers {
 	}
 
 	/**
+	 * Checks if the user has agreed to the terms and privacy policy.
+	 *
+	 * @return bool True if the user has agreed, otherwise false.
+	 */
+	public function has_agreed_terms_pp() {
+		$options = get_option( Wp_Rag::OPTION_NAME_FOR_TERMS_PP );
+
+		return $options && ! empty( $options['agreed'] );
+	}
+
+	/**
 	 * Updates the option for the terms and privacy policy.
 	 *
 	 * @return void

--- a/core/includes/classes/class-wp-rag-page-general-settings.php
+++ b/core/includes/classes/class-wp-rag-page-general-settings.php
@@ -75,7 +75,7 @@ class Wp_Rag_Page_GeneralSettings {
 						'primary',
 						'submit',
 						true,
-						array( 'disabled' => 'true' )
+						WPRAG()->helpers->has_agreed_terms_pp() ? array() : array( 'disabled' => 'true' )
 					);
 				}
 				?>


### PR DESCRIPTION
## Description

We introduced the "PP Consent" feature in the previous PR.
It works as expected for existing sites that are already registered in our system, but it doesn't work correctly for new sites **when they agree to the PP before registration**.

## How to reproduce the bug

### 1. Reset environment:

```bash
docker compose down -v # WARN: All existing data on the local env will be lost.
docker compose up -d

# Wait a few seconds for all services to be up.

docker compose exec wordpress bash -c 'wp core install \
  --url="$WORDPRESS_URL" \
  --title="$WORDPRESS_TITLE" \
  --admin_user="$WORDPRESS_ADMIN_USER" \
  --admin_password="$WORDPRESS_ADMIN_PASSWORD" \
  --admin_email="$WORDPRESS_ADMIN_EMAIL" \
  --skip-email \
  --allow-root'

docker compose exec wordpress wp plugin activate wp-rag --allow-root
```

### 2. Open "General Settings"

http://localhost:8080/wp-admin/admin.php?page=wp-rag-general-settings

### 3. Agree the PP

Click "Accept Terms and Privacy Policy" button on the PP consent card.

## What I expected

"Register" button on the General Settings is enabled.

## Actual behavior

It is disabled, and cannot be enabled anymore.

<img width="486" height="504" alt="Screenshot 2025-07-18 at 3 50 10" src="https://github.com/user-attachments/assets/e25ad104-9f5c-4f1e-b2cf-1b05dd359b15" />
