### PR TITLE
Not to show notice and load scripts on other pages than WP RAG

### DIFF
--- a/core/includes/classes/class-wp-rag-terms-pp-notice.php
+++ b/core/includes/classes/class-wp-rag-terms-pp-notice.php
@@ -30,8 +30,14 @@ class Wp_Rag_TermsPPNotice {
 
 	/**
 	 * Loads the script and style files
+	 *
+	 * @param string $hook page ID.
 	 */
-	public function enqueue_scripts() {
+	public function enqueue_scripts( $hook ) {
+		if ( false === strpos( $hook, 'wp-rag' ) ) {
+			return;
+		}
+
 		$options = get_option( Wp_Rag::OPTION_NAME_FOR_TERMS_PP );
 		if ( $options && isset( $options['agreed'] ) && $options['agreed'] ) {
 			return;
@@ -66,6 +72,12 @@ class Wp_Rag_TermsPPNotice {
 	 * @return void
 	 */
 	public function show_terms_pp_notice() {
+		// Check if the current page is of WP RAG.
+		$screen = get_current_screen();
+		if ( false === strpos( $screen->id, 'wp-rag' ) ) {
+			return;
+		}
+
 		$options = get_option( Wp_Rag::OPTION_NAME_FOR_TERMS_PP );
 		if ( $options && isset( $options['agreed'] ) && $options['agreed'] ) {
 			return;


### PR DESCRIPTION
## What I did

Fix methods for loading the scripts and showing the notice for the terms and privacy policy so that they do nothing when they are called on the other pages than WP RAG.

## How to test this

* Run `delete from wp_options where option_name = 'wp_rag_terms_pp';` on the WordPress DB.
* Confirm the following:
  * The notice is displayed on any of the WP RAG admin pages.
  * The notice isn't displayed on any other admin pages.
