### PR TITLE
Check premium key on some form fields

### DIFF
--- a/core/includes/classes/class-wp-rag-form-helpers.php
+++ b/core/includes/classes/class-wp-rag-form-helpers.php
@@ -19,6 +19,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Wp_Rag_FormHelpers {
 
 	/**
+	 * Returns 'disabled' unless the site is not verified, otherwise ''.
+	 *
+	 * @param bool $display Whether to echo the output or return it.
+	 * @return string
+	 */
+	public function disabled_unless_verified( bool $display = true ): string {
+		return disabled( ! WPRAG()->helpers->is_verified(), true, $display );
+	}
+
+	/**
+	 * Returns 'disabled' unless the site has a premium API key, otherwise ''.
+	 *
+	 * @param bool $display Whether to echo the output or return it.
+	 * @return string
+	 */
+	public function disabled_unless_premium_api_key( bool $display = true ): string {
+		return disabled( ! WPRAG()->helpers->has_premium_api_key(), true, $display );
+	}
+
+	/**
 	 * Returns 'disabled' if forms should be disabled, otherwise ''.
 	 *
 	 * @param string $output The method echos the returned value if 'yes'.

--- a/core/includes/classes/class-wp-rag-form-helpers.php
+++ b/core/includes/classes/class-wp-rag-form-helpers.php
@@ -37,20 +37,4 @@ class Wp_Rag_FormHelpers {
 	public function disabled_unless_premium_api_key( bool $display = true ): string {
 		return disabled( ! WPRAG()->helpers->has_premium_api_key(), true, $display );
 	}
-
-	/**
-	 * Returns 'disabled' if forms should be disabled, otherwise ''.
-	 *
-	 * @param string $output The method echos the returned value if 'yes'.
-	 * @return string
-	 */
-	public function maybe_disabled( string $output = 'yes' ): string {
-		$disabled = ! WPRAG()->helpers->is_verified() ? 'disabled' : '';
-
-		if ( 'yes' === $output ) {
-			echo esc_attr( $disabled );
-		}
-
-		return $disabled;
-	}
 }

--- a/core/includes/classes/class-wp-rag-helpers.php
+++ b/core/includes/classes/class-wp-rag-helpers.php
@@ -178,6 +178,8 @@ class Wp_Rag_Helpers {
 	 *
 	 * Note that it only checks the DB, and doesn't check the API.
 	 *
+	 * TODO: We should check if the key has expired.
+	 *
 	 * @return bool True if verified, otherwise false
 	 */
 	public function has_premium_api_key() {

--- a/core/includes/classes/class-wp-rag-helpers.php
+++ b/core/includes/classes/class-wp-rag-helpers.php
@@ -170,7 +170,18 @@ class Wp_Rag_Helpers {
 	 * @return bool True if verified, otherwise false
 	 */
 	public function is_verified() {
-		return ! empty( $this->get_auth_data( 'verified_at' ) ) || ! empty( $this->get_auth_data( 'premium_api_key' ) );
+		return ! empty( $this->get_auth_data( 'verified_at' ) ) || $this->has_premium_api_key();
+	}
+
+	/**
+	 * Return whether the site has a premium API key or not.
+	 *
+	 * Note that it only checks the DB, and doesn't check the API.
+	 *
+	 * @return bool True if verified, otherwise false
+	 */
+	public function has_premium_api_key() {
+		return ! empty( $this->get_auth_data( 'premium_api_key' ) );
 	}
 
 	/**

--- a/core/includes/classes/class-wp-rag-page-ai-configuration.php
+++ b/core/includes/classes/class-wp-rag-page-ai-configuration.php
@@ -127,7 +127,7 @@ class Wp_Rag_Page_AiConfiguration {
 		?>
 		<input type="text" name="<?php echo self::OPTION_NAME; ?>[openai_api_key]"
 				value="<?php echo esc_attr( $options['openai_api_key'] ?? '' ); ?>"
-			<?php WPRAG()->form->maybe_disabled(); ?>
+			<?php WPRAG()->form->disabled_unless_verified(); ?>
 		/>
 		<?php
 	}
@@ -137,7 +137,7 @@ class Wp_Rag_Page_AiConfiguration {
 		?>
 		<input type="text" name="<?php echo self::OPTION_NAME; ?>[claude_api_key]"
 				value="<?php echo esc_attr( $options['claude_api_key'] ?? '' ); ?>"
-			<?php WPRAG()->form->maybe_disabled(); ?>
+			<?php WPRAG()->form->disabled_unless_verified(); ?>
 		/>
 		<?php
 	}
@@ -185,7 +185,7 @@ class Wp_Rag_Page_AiConfiguration {
 			}
 		}
 		?>
-		<select name="<?php echo self::OPTION_NAME; ?>[embedding_model_id]"<?php WPRAG()->form->maybe_disabled(); ?>>
+		<select name="<?php echo self::OPTION_NAME; ?>[embedding_model_id]"<?php WPRAG()->form->disabled_unless_premium_api_key(); ?>>
 			<option value="openai-text-embedding-3-large" <?php selected( $current_value, 'openai-text-embedding-3-large' ); ?>>OpenAI text-embedding-3-large</option>
 			<option value="openai-text-embedding-3-small" <?php selected( $current_value, 'openai-text-embedding-3-small' ); ?>>OpenAI text-embedding-3-small</option>
 		</select>
@@ -201,7 +201,7 @@ class Wp_Rag_Page_AiConfiguration {
 		$options       = get_option( self::OPTION_NAME );
 		$current_value = $options['generation_model_id'] ?? 'openai-gpt-4o';
 		?>
-		<select name="<?php echo self::OPTION_NAME; ?>[generation_model_id]"<?php WPRAG()->form->maybe_disabled(); ?>>
+		<select name="<?php echo self::OPTION_NAME; ?>[generation_model_id]"<?php WPRAG()->form->disabled_unless_premium_api_key(); ?>>
 			<option value="openai-gpt-4o" <?php selected( $current_value, 'openai-gpt-4o' ); ?>>OpenAI gpt-4o</option>
 			<option value="openai-gpt-4o-mini" <?php selected( $current_value, 'openai-gpt-4o-mini' ); ?>>OpenAI gpt-4o-mini</option>
 			<option value="openai-o1-preview" <?php selected( $current_value, 'openai-o1-preview' ); ?>>OpenAI o1-preview</option>
@@ -253,7 +253,7 @@ class Wp_Rag_Page_AiConfiguration {
 		<input type="number" name="<?php echo self::OPTION_NAME; ?>[search][number_of_documents]"
 				value="<?php echo esc_attr( $options['search']['number_of_documents'] ?? '' ); ?>"
 				min="1" max="8"
-			<?php WPRAG()->form->maybe_disabled(); ?>
+			<?php WPRAG()->form->disabled_unless_premium_api_key(); ?>
 		/>
 		<?php
 	}
@@ -267,7 +267,7 @@ class Wp_Rag_Page_AiConfiguration {
 		<input type="number" name="<?php echo self::OPTION_NAME; ?>[search][score_threshold]"
 				value="<?php echo esc_attr( $options['search']['score_threshold'] ?? '' ); ?>"
 				min="0" max="1" step="0.01"
-			<?php WPRAG()->form->maybe_disabled(); ?>
+			<?php WPRAG()->form->disabled_unless_premium_api_key(); ?>
 		/>
 		<?php
 	}
@@ -307,7 +307,7 @@ class Wp_Rag_Page_AiConfiguration {
 		$example = "Please provide an answer based on the following context only.\n\nContext:";
 		?>
 		<textarea name="<?php echo self::OPTION_NAME; ?>[generation][prompt]" rows="10" class="large-text code"
-			<?php WPRAG()->form->maybe_disabled(); ?>
+			<?php WPRAG()->form->disabled_unless_premium_api_key(); ?>
 			><?php echo esc_textarea( $options['generation']['prompt'] ?? '' ); ?></textarea>
 
 		<p class="description">Enter your prompt template. The context will be automatically appended after this prompt.</p>

--- a/core/includes/classes/class-wp-rag-page-ai-configuration.php
+++ b/core/includes/classes/class-wp-rag-page-ai-configuration.php
@@ -215,7 +215,7 @@ class Wp_Rag_Page_AiConfiguration {
 	public function add_search_parameters_section_and_fields() {
 		add_settings_section(
 			'search_parameters_section', // Section ID
-			'Search Parameters (Currently Beta - Premium Feature Coming Soon)', // Title
+			'Search Parameters (Premium Feature)', // Title
 			array( $this, 'search_parameters_section_callback' ), // Callback
 			'wp-rag-ai-configuration' // Slug of the page
 		);
@@ -278,7 +278,7 @@ class Wp_Rag_Page_AiConfiguration {
 	public function add_generation_parameters_section_and_fields() {
 		add_settings_section(
 			'generation_parameters_section', // Section ID
-			'Generation Parameters (Currently Beta - Premium Feature Coming Soon)', // Title
+			'Generation Parameters (Premium Feature)', // Title
 			array( $this, 'generation_parameters_section_callback' ), // Callback
 			'wp-rag-ai-configuration' // Slug of the page
 		);

--- a/core/includes/classes/class-wp-rag-page-chat-ui.php
+++ b/core/includes/classes/class-wp-rag-page-chat-ui.php
@@ -88,7 +88,7 @@ class Wp_Rag_Page_ChatUI {
 		?>
 		<textarea name="<?php echo self::OPTION_NAME; ?>[custom_css]" rows="5" cols="50" style="resize: both;"
 			<?php
-			WPRAG()->form->maybe_disabled()
+			WPRAG()->form->disabled_unless_verified()
 			?>
 			><?php echo esc_textarea( $options['custom_css'] ?? '' ); ?></textarea>
 		<?php
@@ -136,7 +136,7 @@ class Wp_Rag_Page_ChatUI {
 		<input type="text" name="<?php echo self::OPTION_NAME; ?>[initial_message]"
 				value="<?php echo esc_attr( $options['initial_message'] ?? '' ); ?>"
 			<?php
-			WPRAG()->form->maybe_disabled()
+			WPRAG()->form->disabled_unless_verified()
 			?>
 		/>
 		<?php
@@ -151,7 +151,7 @@ class Wp_Rag_Page_ChatUI {
 		<input type="text" name="<?php echo self::OPTION_NAME; ?>[window_title]"
 				value="<?php echo esc_attr( $options['window_title'] ?? '' ); ?>"
 			<?php
-			WPRAG()->form->maybe_disabled()
+			WPRAG()->form->disabled_unless_verified()
 			?>
 		/>
 		<?php
@@ -202,7 +202,7 @@ class Wp_Rag_Page_ChatUI {
 		<input type="text" name="<?php echo self::OPTION_NAME; ?>[input_placeholder_text]"
 				value="<?php echo esc_attr( $options['input_placeholder_text'] ?? '' ); ?>"
 			<?php
-			WPRAG()->form->maybe_disabled()
+			WPRAG()->form->disabled_unless_verified()
 			?>
 		/>
 		<?php
@@ -217,7 +217,7 @@ class Wp_Rag_Page_ChatUI {
 		<input type="text" name="<?php echo self::OPTION_NAME; ?>[send_button_text]"
 				value="<?php echo esc_attr( $options['send_button_text'] ?? '' ); ?>"
 			<?php
-			WPRAG()->form->maybe_disabled()
+			WPRAG()->form->disabled_unless_verified()
 			?>
 		/>
 		<?php
@@ -271,7 +271,7 @@ class Wp_Rag_Page_ChatUI {
 		<input type="text" name="<?php echo self::OPTION_NAME; ?>[bot_name]"
 				value="<?php echo esc_attr( $options['bot_name'] ?? '' ); ?>"
 			<?php
-			WPRAG()->form->maybe_disabled()
+			WPRAG()->form->disabled_unless_verified()
 			?>
 		/>
 		<?php
@@ -286,7 +286,7 @@ class Wp_Rag_Page_ChatUI {
 		<input type="text" name="<?php echo self::OPTION_NAME; ?>[user_name]"
 				value="<?php echo esc_attr( $options['user_name'] ?? '' ); ?>"
 			<?php
-			WPRAG()->form->maybe_disabled()
+			WPRAG()->form->disabled_unless_verified()
 			?>
 		/>
 		<?php
@@ -322,7 +322,7 @@ class Wp_Rag_Page_ChatUI {
 				if ( 'no' === $value ) {
 					echo 'checked="checked"';
 				}
-				WPRAG()->form->maybe_disabled();
+				WPRAG()->form->disabled_unless_verified();
 				?>
 
 		/>No
@@ -331,7 +331,7 @@ class Wp_Rag_Page_ChatUI {
 			if ( 'yes' === $value ) {
 				echo 'checked="checked"';
 			}
-			WPRAG()->form->maybe_disabled();
+			WPRAG()->form->disabled_unless_verified();
 			?>
 
 		/>Yes

--- a/core/includes/classes/class-wp-rag-page-general-settings.php
+++ b/core/includes/classes/class-wp-rag-page-general-settings.php
@@ -212,7 +212,7 @@ class Wp_Rag_Page_GeneralSettings {
 		?>
 		<input type="text" name="<?php echo self::OPTION_NAME; ?>[wordpress_username]"
 				value="<?php echo esc_attr( $options['wordpress_username'] ?? '' ); ?>"
-			<?php WPRAG()->form->maybe_disabled(); ?>
+			<?php WPRAG()->form->disabled_unless_verified(); ?>
 		/>
 		<?php
 	}
@@ -222,7 +222,7 @@ class Wp_Rag_Page_GeneralSettings {
 		?>
 		<input type="text" name="<?php echo self::OPTION_NAME; ?>[wordpress_password]"
 				value="<?php echo esc_attr( $options['wordpress_password'] ?? '' ); ?>"
-			<?php WPRAG()->form->maybe_disabled(); ?>
+			<?php WPRAG()->form->disabled_unless_verified(); ?>
 		/>
 		<?php
 	}


### PR DESCRIPTION
## What I Did

- The form fields related to the premium feature are now disabled even after the registration has finished, when the API key is not for the premium
  - AI Model, Search Parameters, Generation Parameters on the "AI Configuration" setting page

## What I Confirmed

### For a Free API Key

1. After resetting the environment (dropping all data), I registered the site with a free API key.
2. After site registration finished, I confirmed all form fields remained disabled.
3. Submitted the form with an OpenAI API key, which was successfully updated without errors.

### For a Premium API Key

1. After registering a premium API key, I confirmed all form fields were enabled.
2. Submitted the form by changing AI models, Search Parameters, and Generation Parameters, confirming all fields were successfully updated.
3. Emptied Search Parameters and Generation Parameters and submitted the form; these fields were successfully updated without errors (Number of Documents and Similarity Thresholds returned to default).