### PR TITLE
More customizable UI

### DIFF
--- a/core/includes/assets/js/frontend-scripts.js
+++ b/core/includes/assets/js/frontend-scripts.js
@@ -81,9 +81,9 @@ Frontend related javascript
 			const chatIcon       = $( '#wp-rag-chat-icon' );
 			const form           = $( '#wp-rag-chat-form' );
 			const input          = $( '#wp-rag-chat-input' );
-			const submitButton   = form.find( '.wp-rag-chat__submit' );
+			const submitButton   = $( '#wp-rag-chat-submit-button' );
 			const messages       = $( '#wp-rag-chat-messages' );
-			const minimizeButton = $( '.wp-rag-chat__minimize' );
+			const minimizeButton = $( '#wp-rag-chat-minimize-button' );
 
 			const userName               = wpRag.chat_ui_options['user_name'] || 'You';
 			const botName                = wpRag.chat_ui_options['bot_name'] || 'Bot';

--- a/core/includes/assets/js/frontend-scripts.js
+++ b/core/includes/assets/js/frontend-scripts.js
@@ -85,15 +85,17 @@ Frontend related javascript
 			const messages       = $( '#wp-rag-chat-messages' );
 			const minimizeButton = $( '.wp-rag-chat__minimize' );
 
-			const userName       = wpRag.chat_ui_options['user_name'] || 'You';
-			const botName        = wpRag.chat_ui_options['bot_name'] || 'Bot';
-			const initialMessage = wpRag.chat_ui_options['initial_message'];
+			const userName               = wpRag.chat_ui_options['user_name'] || 'You';
+			const botName                = wpRag.chat_ui_options['bot_name'] || 'Bot';
+			const initialMessage         = wpRag.chat_ui_options['initial_message'];
+			const initialChatWindowState = wpRag.chat_ui_options['initial_chat_window_state'];
 
 			if ( initialMessage ) {
 				showBotMessage(messages, botName, initialMessage);
 			}
 
-			const isMinimized = localStorage.getItem( 'wp-rag-chat-minimized' ) === 'true';
+			const minimizedInStorage = localStorage.getItem( 'wp-rag-chat-minimized' )
+			const isMinimized        = minimizedInStorage === 'true' || (minimizedInStorage === null && initialChatWindowState === 'minimized');
 			if (isMinimized) {
 				chatWindow.addClass( 'wp-rag--hidden' );
 				chatIcon.removeClass( 'wp-rag--hidden' );

--- a/core/includes/assets/js/frontend-scripts.js
+++ b/core/includes/assets/js/frontend-scripts.js
@@ -35,17 +35,17 @@ Frontend related javascript
 
 	function showUserMessage(messages, userName, message) {
 		const container = $( '<div class="wp-rag-message wp-rag-message--user"></div>' );
-		container.append( $(' <div class="wp-rag-message__author">').text( userName ) )
-		container.append( $( '<div class="wp-rag-message__text--user">').text( message ) );
+		container.append( $( '<div class="wp-rag-message__author">' ).text( userName ) )
+		container.append( $( '<div class="wp-rag-message__text--user">' ).text( message ) );
 		messages.append( container );
 	}
 
 	function showBotMessage(messages, botName, message, contextPosts = null) {
 		const container = $( '<div class="wp-rag-message wp-rag-message--bot"></div>' );
-		container.append( $(' <div class="wp-rag-message__author--bot">').text( botName ) )
-		container.append( $( '<div class="wp-rag-message__text--bot">').text( message ) );
+		container.append( $( '<div class="wp-rag-message__author--bot">' ).text( botName ) )
+		container.append( $( '<div class="wp-rag-message__text--bot">' ).text( message ) );
 		if (contextPosts !== null) {
-			showContextLinks(container, contextPosts)
+			showContextLinks( container, contextPosts )
 		}
 		messages.append( container );
 	}
@@ -62,7 +62,7 @@ Frontend related javascript
 		titleDiv.append( '<span class="wp-rag-related__text">Related info</span>' );
 		relatedInfoDiv.append( titleDiv );
 
-		const linksDiv = $( '<div class="wp-rag-related__links"></div>' );
+		const linksDiv  = $( '<div class="wp-rag-related__links"></div>' );
 		contextPosts.forEach(
 			post => {
 				const a = $( `<a href="${post.url}" target="_blank" class="wp-rag-related__link"></a>` );
@@ -91,7 +91,7 @@ Frontend related javascript
 			const initialChatWindowState = wpRag.chat_ui_options['initial_chat_window_state'];
 
 			if ( initialMessage ) {
-				showBotMessage(messages, botName, initialMessage);
+				showBotMessage( messages, botName, initialMessage );
 			}
 
 			const minimizedInStorage = localStorage.getItem( 'wp-rag-chat-minimized' )
@@ -140,11 +140,11 @@ Frontend related javascript
 							},
 							success: function (response) {
 								if (response.success) {
-									showUserMessage(messages, userName, message);
+									showUserMessage( messages, userName, message );
 									if ('yes' === wpRag.chat_ui_options['display_context_links']) {
-										showBotMessage(messages, botName, response.data.answer, response.data.context_posts);
+										showBotMessage( messages, botName, response.data.answer, response.data.context_posts );
 									} else {
-										showBotMessage(messages, botName, response.data.answer);
+										showBotMessage( messages, botName, response.data.answer );
 									}
 								} else {
 									messages.append( '<p><strong>Error:</strong> ' + response.data + '</p>' );

--- a/core/includes/classes/class-wp-rag-frontend.php
+++ b/core/includes/classes/class-wp-rag-frontend.php
@@ -18,6 +18,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Wp_Rag_Frontend {
 	private $shortcode_used = false;
 
+
+	/**
+	 * @since 0.7.0
+	 */
+	public $chat_ui_options = array();
+
 	/**
 	 * Enqueue the frontend related scripts and styles for this plugin.
 	 *
@@ -27,7 +33,7 @@ class Wp_Rag_Frontend {
 	 * @return  void
 	 */
 	public function enqueue_scripts_and_styles() {
-		$chat_ui_options = get_option( WPRAG()->pages['chat-ui']::OPTION_NAME );
+		$this->chat_ui_options = get_option( WPRAG()->pages['chat-ui']::OPTION_NAME );
 
 		wp_enqueue_style( 'dashicons' );
 		wp_enqueue_style( 'wprag-frontend-styles', WPRAG_PLUGIN_URL . 'core/includes/assets/css/frontend-styles.css', array(), WPRAG_VERSION, 'all' );
@@ -36,7 +42,7 @@ class Wp_Rag_Frontend {
 			'wprag-frontend-scripts',
 			'wpRag',
 			array(
-				'chat_ui_options' => $chat_ui_options,
+				'chat_ui_options' => $this->chat_ui_options,
 				'ajaxurl'         => admin_url( 'admin-ajax.php' ),
 				'security_nonce'  => wp_create_nonce( 'your-nonce-name' ),
 			)
@@ -61,25 +67,37 @@ class Wp_Rag_Frontend {
 		<div id="wp-rag-chat-window" class="wp-rag-chat">
 			<div class="wp-rag-chat__header">
 				<span class="wp-rag-chat__title"><?php echo esc_html( $title ); ?></span>
-				<button type="button" id="wp-rag-chat-minimize-button" class="wp-rag-chat__minimize">
-					<span class="dashicons dashicons-minus"></span>
-				</button>
+				<?php if ( ! empty( $this->chat_ui_options['html_minimize_button'] ) ) : ?>
+					<?php echo wp_kses_post( $this->chat_ui_options['html_minimize_button'] ); ?>
+				<?php else : ?>
+					<button type="button" id="wp-rag-chat-minimize-button" class="wp-rag-chat__minimize">
+						<span class="dashicons dashicons-minus"></span>
+					</button>
+				<?php endif; ?>
 			</div>
 			<div class="wp-rag-chat__content">
 				<div id="wp-rag-chat-messages" class="wp-rag-chat__messages"></div>
 				<form id="wp-rag-chat-form" class="wp-rag-chat__form">
 					<input type="text" id="wp-rag-chat-input" class="wp-rag-chat__input" placeholder="<?php echo esc_attr( $placeholder ); ?>">
-					<button type="submit" id="wp-rag-chat-submit-button" class="wp-rag-chat__submit">
-						<span class="wp-rag-chat__submit-text"><?php echo esc_html( $send_button_text ); ?></span>
-						<span class="wp-rag-chat__spinner"></span>
-					</button>
+					<?php if ( ! empty( $this->chat_ui_options['html_submit_button'] ) ) : ?>
+						<?php echo wp_kses_post( $this->chat_ui_options['html_submit_button'] ); ?>
+					<?php else : ?>
+						<button type="submit" id="wp-rag-chat-submit-button" class="wp-rag-chat__submit">
+							<span class="wp-rag-chat__submit-text"><?php echo esc_html( $send_button_text ); ?></span>
+							<span class="wp-rag-chat__spinner"></span>
+						</button>
+					<?php endif; ?>
 				</form>
 			</div>
 		</div>
-		<div id="wp-rag-chat-icon" class="wp-rag-chat-launcher wp-rag--hidden">
-			<span class="dashicons dashicons-admin-comments"></span>
-			<span class="wp-rag-chat-launcher__tooltip">Open <?php echo esc_html( $title ); ?></span>
-		</div>
+		<?php if ( ! empty( $this->chat_ui_options['html_minimized_icon'] ) ) : ?>
+			<?php echo wp_kses_post( $this->chat_ui_options['html_minimized_icon'] ); ?>
+		<?php else : ?>
+			<div id="wp-rag-chat-icon" class="wp-rag-chat-launcher wp-rag--hidden">
+				<span class="dashicons dashicons-admin-comments"></span>
+				<span class="wp-rag-chat-launcher__tooltip">Open <?php echo esc_html( $title ); ?></span>
+			</div>
+		<?php endif; ?>
 		<?php
 	}
 

--- a/core/includes/classes/class-wp-rag-frontend.php
+++ b/core/includes/classes/class-wp-rag-frontend.php
@@ -52,7 +52,7 @@ class Wp_Rag_Frontend {
 	/**
 	 * @return string|void HTML for the chat window
 	 */
-	function show_chat_window() {
+	public function show_chat_window() {
 		// When the shortcode wasn't used, do nothing.
 		if ( empty( $this->shortcode_used ) ) {
 			return '';
@@ -109,7 +109,7 @@ class Wp_Rag_Frontend {
 		$data     = array( 'question' => $message );
 		$response = WPRAG()->helpers->call_api_for_site( '/posts/query', 'POST', $data );
 
-		if ( $response['httpCode'] !== 200 ) {
+		if ( 200 !== $response['httpCode'] ) {
 			wp_send_json_error( $response['response'], $response['httpCode'] );
 		} else {
 			wp_send_json_success( $response['response'] );

--- a/core/includes/classes/class-wp-rag-frontend.php
+++ b/core/includes/classes/class-wp-rag-frontend.php
@@ -52,9 +52,9 @@ class Wp_Rag_Frontend {
 			return '';
 		}
 
-		$options     = get_option( WP_RAG::instance()->pages['chat-ui']::OPTION_NAME );
-		$title       = ! empty( $options['window_title'] ) ? $options['window_title'] : 'Chat';
-		$placeholder = ! empty( $options['input_placeholder_text'] ) ? $options['input_placeholder_text']
+		$options          = get_option( WP_RAG::instance()->pages['chat-ui']::OPTION_NAME );
+		$title            = ! empty( $options['window_title'] ) ? $options['window_title'] : 'Chat';
+		$placeholder      = ! empty( $options['input_placeholder_text'] ) ? $options['input_placeholder_text']
 			: 'Enter your message here...';
 		$send_button_text = ! empty( $options['send_button_text'] ) ? $options['send_button_text'] : 'Send';
 		?>

--- a/core/includes/classes/class-wp-rag-frontend.php
+++ b/core/includes/classes/class-wp-rag-frontend.php
@@ -61,7 +61,7 @@ class Wp_Rag_Frontend {
 		<div id="wp-rag-chat-window" class="wp-rag-chat">
 			<div class="wp-rag-chat__header">
 				<span class="wp-rag-chat__title"><?php echo esc_html( $title ); ?></span>
-				<button type="button" class="wp-rag-chat__minimize">
+				<button type="button" id="wp-rag-chat-minimize-button" class="wp-rag-chat__minimize">
 					<span class="dashicons dashicons-minus"></span>
 				</button>
 			</div>
@@ -69,7 +69,7 @@ class Wp_Rag_Frontend {
 				<div id="wp-rag-chat-messages" class="wp-rag-chat__messages"></div>
 				<form id="wp-rag-chat-form" class="wp-rag-chat__form">
 					<input type="text" id="wp-rag-chat-input" class="wp-rag-chat__input" placeholder="<?php echo esc_attr( $placeholder ); ?>">
-					<button type="submit" class="wp-rag-chat__submit">
+					<button type="submit" id="wp-rag-chat-submit-button" class="wp-rag-chat__submit">
 						<span class="wp-rag-chat__submit-text"><?php echo esc_html( $send_button_text ); ?></span>
 						<span class="wp-rag-chat__spinner"></span>
 					</button>

--- a/core/includes/classes/class-wp-rag-frontend.php
+++ b/core/includes/classes/class-wp-rag-frontend.php
@@ -20,12 +20,14 @@ class Wp_Rag_Frontend {
 
 
 	/**
-	 * @since 0.7.0
+	 * The options entered in the Chat UI page.
+	 *
+	 * @since 0.8.0
 	 */
 	public $chat_ui_options = array();
 
 	/**
-	 * Enqueue the frontend related scripts and styles for this plugin.
+	 * Enqueue the frontend-related scripts and styles for this plugin.
 	 *
 	 * @access  public
 	 * @since   0.0.1

--- a/core/includes/classes/class-wp-rag-helpers.php
+++ b/core/includes/classes/class-wp-rag-helpers.php
@@ -446,4 +446,49 @@ class Wp_Rag_Helpers {
 			return true;
 		}
 	}
+
+	/**
+	 * Sanitize custom HTML entered by the user.
+	 *
+	 * @param string $input The custom HTML entered by the user.
+	 */
+	public function sanitize_custom_html( $input ) {
+		$allowed_tags = array(
+			'div'    => array(
+				'id'    => array(),
+				'class' => array(),
+				'style' => array(),
+			),
+			'span'   => array(
+				'class' => array(),
+				'style' => array(),
+			),
+			'p'      => array(
+				'class' => array(),
+				'style' => array(),
+			),
+			'h1'     => array(
+				'class' => array(),
+				'style' => array(),
+			),
+			'h2'     => array(
+				'class' => array(),
+				'style' => array(),
+			),
+			'h3'     => array(
+				'class' => array(),
+				'style' => array(),
+			),
+			'a'      => array(
+				'href'  => array(),
+				'class' => array(),
+				'style' => array(),
+			),
+			'strong' => array(),
+			'em'     => array(),
+			'br'     => array(),
+		);
+
+		return wp_kses( $input, $allowed_tags );
+	}
 }

--- a/core/includes/classes/class-wp-rag-helpers.php
+++ b/core/includes/classes/class-wp-rag-helpers.php
@@ -454,6 +454,12 @@ class Wp_Rag_Helpers {
 	 */
 	public function sanitize_custom_html( $input ) {
 		$allowed_tags = array(
+			'button' => array(
+				'type'  => array(),
+				'id'    => array(),
+				'class' => array(),
+				'style' => array(),
+			),
 			'div'    => array(
 				'id'    => array(),
 				'class' => array(),

--- a/core/includes/classes/class-wp-rag-helpers.php
+++ b/core/includes/classes/class-wp-rag-helpers.php
@@ -118,8 +118,8 @@ class Wp_Rag_Helpers {
 
 		// Handle inactive premium API key error.
 		if ( ! empty( $premium_api_key ) &&
-		     isset( $result['headers']['X-Auth-Failure-Reason'] ) &&
-		     'INACTIVE_PREMIUM_API_KEY' === $result['headers']['X-Auth-Failure-Reason'] ) {
+			isset( $result['headers']['X-Auth-Failure-Reason'] ) &&
+			'INACTIVE_PREMIUM_API_KEY' === $result['headers']['X-Auth-Failure-Reason'] ) {
 
 			// Clear premium API key data from database.
 			$this->delete_key_from_auth_data( 'premium_api_key' );
@@ -128,7 +128,7 @@ class Wp_Rag_Helpers {
 			// Retry with free API key if available.
 			if ( ! empty( $free_api_key ) ) {
 				$headers['X-Api-Key'] = $free_api_key;
-				$result = $this->call_api( $api_path, $method, $data, $headers );
+				$result               = $this->call_api( $api_path, $method, $data, $headers );
 			}
 		}
 
@@ -178,7 +178,7 @@ class Wp_Rag_Helpers {
 		return array(
 			'httpCode' => wp_remote_retrieve_response_code( $response ),
 			'response' => json_decode( wp_remote_retrieve_body( $response ), true ),
-			'headers' => wp_remote_retrieve_headers( $response ),
+			'headers'  => wp_remote_retrieve_headers( $response ),
 		);
 	}
 
@@ -237,9 +237,9 @@ class Wp_Rag_Helpers {
 			);
 			return false;
 		} else {
-			$auth_data                      = WPRAG()->helpers->get_auth_data();
-			$auth_data['site_id']           = $response['response']['id'];
-			$auth_data['free_api_key']      = $response['response']['free_api_key'];
+			$auth_data                 = WPRAG()->helpers->get_auth_data();
+			$auth_data['site_id']      = $response['response']['id'];
+			$auth_data['free_api_key'] = $response['response']['free_api_key'];
 
 			// Only set verification_code if it exists (not set for premium sites).
 			if ( isset( $response['response']['verification_code'] ) ) {
@@ -401,15 +401,15 @@ class Wp_Rag_Helpers {
 	/**
 	 * Updates the site with a premium API key.
 	 *
-	 * @param int $site_id The site ID
+	 * @param int    $site_id The site ID
 	 * @param string $premium_api_key The premium API key to add
 	 * @return bool
 	 */
 	public function update_site_premium_key( $site_id, $premium_api_key ): bool {
 		$api_path = "/api/sites/$site_id";
 		$data     = array(
-			'url' => get_site_url(),
-			'premium_api_key' => $premium_api_key
+			'url'             => get_site_url(),
+			'premium_api_key' => $premium_api_key,
 		);
 
 		$response = $this->call_api( $api_path, 'PUT', $data, array( 'X-Api-Key' => $this->get_auth_data( 'free_api_key' ) ) );

--- a/core/includes/classes/class-wp-rag-page-chat-ui.php
+++ b/core/includes/classes/class-wp-rag-page-chat-ui.php
@@ -25,7 +25,7 @@ class Wp_Rag_Page_ChatUI {
 	/**
 	 * @var array Field names for custom HTML fields. These fields will be sanitized using `sanitize_custom_html`.
 	 *
-	 * @since 0.7.0
+	 * @since 0.8.0
 	 */
 	private $custom_html_fields = array(
 		'html_minimize_button',
@@ -58,7 +58,7 @@ class Wp_Rag_Page_ChatUI {
 	 * Used for the `sanitize_callback` passed to `register_setting`.
 	 *
 	 * @param array $input input options.
-	 * @since 0.7.0
+	 * @since 0.8.0
 	 */
 	public function sanitize_custom_html_fields( $input ) {
 		$sanitized_input = sanitize_post( $input, 'db' );
@@ -345,7 +345,7 @@ class Wp_Rag_Page_ChatUI {
 		);
 	}
 
-	function display_options_section_callback() {
+	public function display_options_section_callback() {
 		echo '';
 	}
 
@@ -400,7 +400,7 @@ class Wp_Rag_Page_ChatUI {
 	}
 
 	/**
-	 * @since 0.7.0
+	 * @since 0.8.0
 	 */
 	public function add_custom_html_section_and_fields() {
 		add_settings_section(
@@ -438,7 +438,7 @@ class Wp_Rag_Page_ChatUI {
 	}
 
 	/**
-	 * @since 0.7.0
+	 * @since 0.8.0
 	 */
 	public function custom_html_section_callback() {
 		?>
@@ -453,7 +453,7 @@ class Wp_Rag_Page_ChatUI {
 	}
 
 	/**
-	 * @since 0.7.0
+	 * @since 0.8.0
 	 */
 	public function html_minimize_button_field_render() {
 		$options = get_option( self::OPTION_NAME );
@@ -468,7 +468,7 @@ class Wp_Rag_Page_ChatUI {
 	}
 
 	/**
-	 * @since 0.7.0
+	 * @since 0.8.0
 	 */
 	public function html_submit_button_field_render() {
 		$options = get_option( self::OPTION_NAME );
@@ -484,7 +484,7 @@ class Wp_Rag_Page_ChatUI {
 	}
 
 	/**
-	 * @since 0.7.0
+	 * @since 0.8.0
 	 */
 	public function html_minimized_icon_field_render() {
 		$options = get_option( self::OPTION_NAME );

--- a/core/includes/classes/class-wp-rag-page-chat-ui.php
+++ b/core/includes/classes/class-wp-rag-page-chat-ui.php
@@ -297,7 +297,10 @@ class Wp_Rag_Page_ChatUI {
 			'display_options_section',
 			'Display Options',
 			array( $this, 'display_options_section_callback' ),
-			'wp-rag-chat-ui'
+			'wp-rag-chat-ui',
+			array(
+				'after_section' => '<hr />',
+			)
 		);
 
 		add_settings_field(
@@ -368,6 +371,105 @@ class Wp_Rag_Page_ChatUI {
 				?>
 
 		/>Minimized
+		<?php
+	}
+
+	/**
+	 * @since 0.7.0
+	 */
+	public function add_custom_html_section_and_fields() {
+		add_settings_section(
+			'custom_html_section',
+			'Custom HTML (For Advanced Users, Beta Feature)',
+			array( $this, 'custom_html_section_callback' ),
+			'wp-rag-chat-ui'
+		);
+
+		// Remember to add the custom HTML fields to the $custom_html_fields array!
+
+		add_settings_field(
+			'html_minimize_button',
+			'Minimize Button',
+			array( $this, 'html_minimize_button_field_render' ),
+			'wp-rag-chat-ui',
+			'custom_html_section'
+		);
+
+		add_settings_field(
+			'html_submit_button',
+			'Submit Button',
+			array( $this, 'html_submit_button_field_render' ),
+			'wp-rag-chat-ui',
+			'custom_html_section'
+		);
+
+		add_settings_field(
+			'html_minimized_icon',
+			'Minimized Icon',
+			array( $this, 'html_minimized_icon_field_render' ),
+			'wp-rag-chat-ui',
+			'custom_html_section'
+		);
+	}
+
+	/**
+	 * @since 0.7.0
+	 */
+	public function custom_html_section_callback() {
+		?>
+		<div>
+			Tips:
+			<ul>
+				<li>Start with copy-and-pasting the HTML code of the relevant section from <code>core/includes/classes/class-wp-rag-frontend.php</code>.</li>
+				<li>If you have any issues, emptying the field will revert to the default UI.</li>
+			</ul>
+		</div>
+		<?php
+	}
+
+	/**
+	 * @since 0.7.0
+	 */
+	public function html_minimize_button_field_render() {
+		$options = get_option( self::OPTION_NAME );
+		?>
+		<textarea name="<?php echo self::OPTION_NAME; ?>[html_minimize_button]" rows="5" cols="50" style="resize: both;"
+			<?php
+			WPRAG()->form->disabled_unless_verified()
+			?>
+			><?php echo esc_textarea( $options['html_minimize_button'] ?? '' ); ?></textarea>
+		<p class="description">The parent element must have <code>id="wp-rag-chat-minimize-button"</code>.</p>
+		<?php
+	}
+
+	/**
+	 * @since 0.7.0
+	 */
+	public function html_submit_button_field_render() {
+		$options = get_option( self::OPTION_NAME );
+		?>
+		<textarea name="<?php echo self::OPTION_NAME; ?>[html_submit_button]" rows="5" cols="50" style="resize: both;"
+			<?php
+			WPRAG()->form->disabled_unless_verified()
+			?>
+			><?php echo esc_textarea( $options['html_submit_button'] ?? '' ); ?></textarea>
+		<p class="description">The parent element must have <code>id="wp-rag-chat-submit-button"</code>.</p>
+		<p class="description">If you specify this, the value in "Send Button Text" will be ignored.</p>
+		<?php
+	}
+
+	/**
+	 * @since 0.7.0
+	 */
+	public function html_minimized_icon_field_render() {
+		$options = get_option( self::OPTION_NAME );
+		?>
+		<textarea name="<?php echo self::OPTION_NAME; ?>[html_minimized_icon]" rows="5" cols="50" style="resize: both;"
+			<?php
+			WPRAG()->form->disabled_unless_verified()
+			?>
+			><?php echo esc_textarea( $options['html_minimized_icon'] ?? '' ); ?></textarea>
+		<p class="description">The parent element must have <code>id="wp-rag-chat-icon"</code> and <code>class="wp-rag--hidden"</code>.</p>
 		<?php
 	}
 }

--- a/core/includes/classes/class-wp-rag-page-chat-ui.php
+++ b/core/includes/classes/class-wp-rag-page-chat-ui.php
@@ -295,14 +295,14 @@ class Wp_Rag_Page_ChatUI {
 	public function add_display_options_section_and_fields() {
 		add_settings_section(
 			'display_options_section',
-			'Display options',
+			'Display Options',
 			array( $this, 'display_options_section_callback' ),
 			'wp-rag-chat-ui'
 		);
 
 		add_settings_field(
 			'display_context_links',
-			'Display context links',
+			'Display Context Links',
 			array( $this, 'display_context_links_field_render' ),
 			'wp-rag-chat-ui',
 			'display_options_section'

--- a/core/includes/classes/class-wp-rag-page-chat-ui.php
+++ b/core/includes/classes/class-wp-rag-page-chat-ui.php
@@ -307,6 +307,14 @@ class Wp_Rag_Page_ChatUI {
 			'wp-rag-chat-ui',
 			'display_options_section'
 		);
+
+		add_settings_field(
+			'initial_chat_window_state',
+			'Initial Chat Window State',
+			array( $this, 'initial_chat_window_state_field_render' ),
+			'wp-rag-chat-ui',
+			'display_options_section'
+		);
 	}
 
 	function display_options_section_callback() {
@@ -318,23 +326,48 @@ class Wp_Rag_Page_ChatUI {
 		$value   = $options['display_context_links'] ?? 'no';
 		?>
 		<input type="radio" name="<?php echo self::OPTION_NAME; ?>[display_context_links]" value="no"
+		<?php
+		if ( 'no' === $value ) {
+			echo 'checked="checked"';
+		}
+		WPRAG()->form->disabled_unless_verified();
+		?>
+
+		/>No
+		<input type="radio" name="<?php echo self::OPTION_NAME; ?>[display_context_links]" value="yes"
+		<?php
+		if ( 'yes' === $value ) {
+			echo 'checked="checked"';
+		}
+		WPRAG()->form->disabled_unless_verified();
+		?>
+
+		/>Yes
+		<?php
+	}
+
+	function initial_chat_window_state_field_render() {
+		$options = get_option( self::OPTION_NAME );
+		$value   = $options['initial_chat_window_state'] ?? 'open';
+		?>
+		<input type="radio" name="<?php echo self::OPTION_NAME; ?>[initial_chat_window_state]" value="open"
 				<?php
-				if ( 'no' === $value ) {
+				if ( 'open' === $value ) {
 					echo 'checked="checked"';
 				}
 				WPRAG()->form->disabled_unless_verified();
 				?>
 
-		/>No
-		<input type="radio" name="<?php echo self::OPTION_NAME; ?>[display_context_links]" value="yes"
-			<?php
-			if ( 'yes' === $value ) {
-				echo 'checked="checked"';
-			}
-			WPRAG()->form->disabled_unless_verified();
-			?>
+		/>Open
+		<input type="radio" name="<?php echo self::OPTION_NAME; ?>[initial_chat_window_state]" value="minimized"
+				<?php
+				if ( 'minimized' === $value ) {
+					echo 'checked="checked"';
+				}
+				WPRAG()->form->disabled_unless_verified();
+				?>
 
-		/>Yes
+		/>Minimized
 		<?php
 	}
 }

--- a/core/includes/classes/class-wp-rag-page-chat-ui.php
+++ b/core/includes/classes/class-wp-rag-page-chat-ui.php
@@ -23,6 +23,17 @@ class Wp_Rag_Page_ChatUI {
 	}
 
 	/**
+	 * @var array Field names for custom HTML fields. These fields will be sanitized using `sanitize_custom_html`.
+	 *
+	 * @since 0.7.0
+	 */
+	private $custom_html_fields = array(
+		'html_minimize_button',
+		'html_submit_button',
+		'html_minimized_icon',
+	);
+
+	/**
 	 * @since 0.0.4
 	 */
 	public function enqueue_admin_styles( $hook ) {
@@ -41,6 +52,20 @@ class Wp_Rag_Page_ChatUI {
 				margin-top: 1em;
 			}'
 		);
+	}
+
+	/**
+	 * Used for the `sanitize_callback` passed to `register_setting`.
+	 *
+	 * @param array $input input options.
+	 * @since 0.7.0
+	 */
+	public function sanitize_custom_html_fields( $input ) {
+		$sanitized_input = sanitize_post( $input, 'db' );
+		foreach ( $this->custom_html_fields as $custom_html_field ) {
+			$sanitized_input[ $custom_html_field ] = WPRAG()->helpers->sanitize_custom_html( $sanitized_input[ $custom_html_field ] );
+		}
+		return $sanitized_input;
 	}
 
 	public function page_content() {

--- a/core/includes/classes/class-wp-rag-run.php
+++ b/core/includes/classes/class-wp-rag-run.php
@@ -337,6 +337,9 @@ class Wp_Rag_Run {
 			register_setting(
 				'wp_rag_options',
 				$cls::OPTION_NAME,
+				array(
+					'sanitize_callback' => array( $cls, 'sanitize_custom_html_fields' ),
+				),
 			);
 
 			$cls->add_appearance_section_and_fields();
@@ -344,6 +347,7 @@ class Wp_Rag_Run {
 			$cls->add_input_and_button_labels_section_and_fields();
 			$cls->add_participant_names_section_and_fields();
 			$cls->add_display_options_section_and_fields();
+			$cls->add_custom_html_section_and_fields();
 		}
 	}
 }


### PR DESCRIPTION
## What I did

* Enable to choose the initial state of the chat window: open or closed
* Enable to use custom HTML for the buttons and minimized icon
  * Add sanitization
* Fix and format code

## Tests
### Initial state of the chat window

1. Remove the local storage of the browser
2. Change the setting on the plugin admin page
3. Open a page with the chat window
4. Confirm the chat window is open/closed
5. Minimize/reopen the chat window
6. Reload the page
7. Confirm the state of the chat window is the same as before

### Custom HTML

1. Enter a custom HTML field with tags that are not allowed (e.g., `<script>`) and save it
2. Confirm that only allowed tags and text are in the field
3. Go to a page with the chat window
4. Confirm the custom HTML is displayed
5. Remove the value of the custom HTML field and save it
6. Go to a page with the chat window
7. Confirm the default UI is displayed

